### PR TITLE
Event type error updated

### DIFF
--- a/src/PasswordStore.sol
+++ b/src/PasswordStore.sol
@@ -13,7 +13,7 @@ contract PasswordStore {
     address private s_owner;
     string private s_password;
 
-    event SetNetPassword();
+    event SetNewPassword();
 
     constructor() {
         s_owner = msg.sender;
@@ -25,7 +25,7 @@ contract PasswordStore {
      */
     function setPassword(string memory newPassword) external {
         s_password = newPassword;
-        emit SetNetPassword();
+        emit SetNewPassword();
     }
 
     /*


### PR DESCRIPTION
In our smart contract event, there is Event named "SetNetPassword"
<img width="386" alt="cyfrin event" src="https://github.com/Cyfrin/3-passwordstore-audit/assets/85685981/1ebdd8cd-419d-439f-85ad-2e09fc682477">
, which updated and changed "SetNewPassword"